### PR TITLE
Add reimports to root folder

### DIFF
--- a/dislash/__init__.py
+++ b/dislash/__init__.py
@@ -1,1 +1,4 @@
+from .interactions import *
+from .slash_commands import *
+
 __version__ = "1.0.0"


### PR DESCRIPTION
This is to fix imports from dislash like `ImportError: cannot import name 'SlashClient' from 'dislash'`.