### PR TITLE
fix: allow message reference when sending

### DIFF
--- a/dislash/slash_commands/slash_client.py
+++ b/dislash/slash_commands/slash_client.py
@@ -906,6 +906,7 @@ class SlashClient:
                                                     embed=None, file=None,
                                                     components=None,
                                                     allowed_mentions=None,
+                                                    reference=None,
                                                     **options):
         state = self.client._get_state()
         data = {**options}
@@ -914,6 +915,11 @@ class SlashClient:
             data["content"] = str(content)
         if embed is not None:
             data["embed"] = embed.to_dict()
+        if reference is not None:
+            data["message_reference"] = {
+                "message_id": reference.id,
+                "channel_id": reference.channel.id
+            }
 
         if allowed_mentions:
             if state.allowed_mentions:


### PR DESCRIPTION
This PR makes a small fix to SlashClient's `_send_with_components` method to allow it to have a message reference. Since it replaces Messagable.send this is required to allow usage of Messagable.reply