### PR TITLE
Add teardown method and move INTERACTION_CREATE to on_socket_response

### DIFF
--- a/dislash/slash_commands/slash_client.py
+++ b/dislash/slash_commands/slash_client.py
@@ -104,6 +104,7 @@ class SlashClient:
         discord.Guild.get_command_named = get_command_named
 
     def teardown(self):
+        '''Cleanup the client by removing all registered listeners and caches.'''
         self.client.remove_listener(self._on_guild_remove, 'on_guild_remove')
         self.client.remove_listener(self._on_socket_response, 'on_socket_response')
         if isinstance(self.client, discord.AutoShardedClient):


### PR DESCRIPTION
This PR adds a teardown method, to be used when deleting the client, it removes all the listeners that are created by the client, clear all caches, and delete `slash` attribute from client if exists.
I also moved `INTERACTION_CREATE` to `on_socket_response` listener so it's easier to delete it on teardown.