### PR TITLE
Interaction is subscriptable now

### DIFF
--- a/dislash/interactions/message_components.py
+++ b/dislash/interactions/message_components.py
@@ -308,7 +308,7 @@ class ActionRow(Component):
             "components": [comp.to_dict() for comp in self.components]
         }
 
-    def disable_buttons(self, *positions: int=None):
+    def disable_buttons(self, *positions: int):
         """
         Sets ``disabled`` to ``True`` for all buttons in this row.
         """
@@ -324,7 +324,7 @@ class ActionRow(Component):
 
 
 
-    def enable_buttons(self, *positions: int=None):
+    def enable_buttons(self, *positions: int):
         """
         Sets ``disabled`` to ``False`` for all buttons in this row.
         """

--- a/dislash/interactions/slash_interaction.py
+++ b/dislash/interactions/slash_interaction.py
@@ -308,17 +308,21 @@ class SlashInteraction(BaseInteraction):
         self.invoked_with = self.data.name
     
     def __repr__(self):
-        return "<SlashInteraction id={0.id} version={0.version} type={0.type} "\
-                "token='{0.token}' guild={0.guild} channel_id={0.channel_id} "\
-                "author={0.author} data={0.data!r}>".format(self)
+        return (
+            "<SlashInteraction id={0.id} version={0.version} type={0.type} "
+            "token='{0.token}' guild={0.guild} channel_id={0.channel_id} "
+            "author={0.author} data={0.data!r}>"
+        ).format(self)
 
     def __getitem__(self, key):
         if isinstance(key, str):
-            opt = self.data.get_option(key)
+            opt = self.data.get(key)
         elif isinstance(key, int):
             opt = self.data.option_at(key)
         else:
             raise TypeError(f'unsupported type of key (str or int required, {type(key)} passed)')
+        if opt is None:
+            return None
         return opt.value if opt.type > 2 else opt
 
     def get(self, name: str, default=None):

--- a/dislash/interactions/slash_interaction.py
+++ b/dislash/interactions/slash_interaction.py
@@ -319,8 +319,6 @@ class SlashInteraction(BaseInteraction):
             opt = self.data.option_at(key)
         else:
             raise TypeError(f'unsupported type of key (str or int required, {type(key)} passed)')
-        if opt is None:
-            raise KeyError(key)
         return opt.value if opt.type > 2 else opt
 
     def get(self, name: str, default=None):

--- a/dislash/interactions/slash_interaction.py
+++ b/dislash/interactions/slash_interaction.py
@@ -311,7 +311,18 @@ class SlashInteraction(BaseInteraction):
         return "<SlashInteraction id={0.id} version={0.version} type={0.type} "\
                 "token='{0.token}' guild={0.guild} channel_id={0.channel_id} "\
                 "author={0.author} data={0.data!r}>".format(self)
-    
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            opt = self.data.get_option(key)
+        elif isinstance(key, int):
+            opt = self.data.option_at(key)
+        else:
+            raise TypeError(f'unsupported type of key (str or int required, {type(key)} passed)')
+        if opt is None:
+            raise KeyError(key)
+        return opt.value if opt.type > 2 else opt
+
     def get(self, name: str, default=None):
         """Equivalent to :class:`InteractionData.get`"""
         return self.data.get(name, default)


### PR DESCRIPTION
I haven't tested this yet, but it should work fine.
Old syntax: 
```py
inter.get('option_name')
inter.option_at(1).value
```
New syntax:
```py
inter['option_name']
inter[1]
```