### PR TITLE
Added BadArgument Error

### DIFF
--- a/dislash/slash_commands/errors.py
+++ b/dislash/slash_commands/errors.py
@@ -20,6 +20,10 @@ class SlashCommandError(DiscordException):
             super().__init__(*args)
 
 
+class BadArgument(SlashCommandError):
+    pass
+            
+            
 class SlashCheckFailure(SlashCommandError):
     pass
 


### PR DESCRIPTION
Just to raise it in code and catch in error handler because **commands.BadArgument** cannot be catched in **on_slash_command_error**